### PR TITLE
Detection of non-existent meters and tafs

### DIFF
--- a/metars/MetarsClass.php
+++ b/metars/MetarsClass.php
@@ -36,4 +36,25 @@ class Metars {
         return $result = $info ? $info->$type : '';
     }
 
+    public function urlExist($url){
+        $agent = "Mozilla/4.0 (compatible; MSIE 5.01; Windows NT 5.0)";$ch=curl_init();
+        curl_setopt ($ch, CURLOPT_URL,$url );
+        curl_setopt($ch, CURLOPT_USERAGENT, $agent);
+        curl_setopt ($ch, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt ($ch,CURLOPT_VERBOSE,false);
+        curl_setopt($ch, CURLOPT_TIMEOUT, 6);
+        curl_setopt($ch,CURLOPT_SSL_VERIFYPEER, FALSE);
+        curl_setopt($ch,CURLOPT_SSLVERSION,3);
+        curl_setopt($ch,CURLOPT_SSL_VERIFYHOST, FALSE);
+        $page=curl_exec($ch);
+        $httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+
+        if($httpcode>=200 && $httpcode<300) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
 }

--- a/metars/metars.php
+++ b/metars/metars.php
@@ -68,9 +68,7 @@ if(isset($_POST['metarsubmit'])) {
             </div>
 
 <?php
-
 if (!empty($icaoFinal) && !empty($airportName)) {
-
 ?>
 
             <div class="col-md-12">
@@ -85,6 +83,10 @@ if (!empty($icaoFinal) && !empty($airportName)) {
             </div>
 
 
+            <?php
+                if ($Metars->urlExist('ftp://tgftp.nws.noaa.gov/data/observations/metar/decoded/' . $icaoFinal . '.TXT')) {
+            ?>
+
             <div class="col-md-6">
                 <div class="panel panel-default">
                     <p class="lead"><?php echo $airportName . ' METARS decoded'; ?></p><br />
@@ -93,6 +95,12 @@ if (!empty($icaoFinal) && !empty($airportName)) {
                     ?>
                 </div>
             </div>
+
+            <?php
+                }
+
+                if ($Metars->urlExist('ftp://tgftp.nws.noaa.gov/data/forecasts/taf/stations/' . $icaoFinal . '.TXT')) {
+            ?>
 
             <div class="col-md-6">
                 <div class="panel panel-default">
@@ -110,10 +118,12 @@ if (!empty($icaoFinal) && !empty($airportName)) {
                 </div>
             </div>
 
+            <?php
+                }
+            ?>
+
 <?php
-
 } elseif (empty($errIcao) && !empty($icao)) { // If the icao and airport name aren't found (i.e. if the info is not in the database)
-
 ?>
         <div class="col-md-6 col-md-offset-3">
             <p class="alert alert-danger"><?php echo 'Sorry, the ICAO ' . $icao . ' is not in our database'; ?></p>
@@ -124,7 +134,7 @@ if (!empty($icaoFinal) && !empty($airportName)) {
 
 ?>
 
-        </div>
+    </div>
 
 
 <?php


### PR DESCRIPTION
The metars page now hides the metar and taf boxes if the airport
doesn’t have any.