### PR TITLE
Pull Long Mynd West cam from midlandgliding.club westcam.html

### DIFF
--- a/webcams/index.html
+++ b/webcams/index.html
@@ -184,10 +184,10 @@
                     <img src="https://www.blackmountainsgliding.co.uk/weather/webcamneweast-sm.jpg" class="img-responsive img-rounded" alt="Talgarth East Webcam"/>
                 </div> -->
 
-                <!-- <div class="col-md-6">
+                <div class="col-md-6">
                     <p class="lead webcam">HusBos West</p>
                     <img
-                        src="http://webcam.theglidingcentre.co.uk/10min/hangarwestcam_0.jpg"
+                        src="https://www.theglidingcentre.co.uk/webcams/10min/hangar_westcam_0.jpg"
                         class="img-responsive img-rounded"
                         alt="HusBos West Webcam"
                     />
@@ -196,11 +196,11 @@
                 <div class="col-md-6">
                     <p class="lead webcam">HusBos South</p>
                     <img
-                        src="http://webcam.theglidingcentre.co.uk/10min/hangarsouthcam_0.jpg"
+                        src="https://www.theglidingcentre.co.uk/webcams/10min/hangar_southcam_0.jpg"
                         class="img-responsive img-rounded"
                         alt="HusBos South Webcam"
                     />
-                </div> -->
+                </div>
 
                 <!-- <div class="col-md-6">
                     <p class="lead webcam">Wormingford South</p>

--- a/webcams/index.html
+++ b/webcams/index.html
@@ -161,7 +161,6 @@
                 <div class="col-md-6">
                     <p class="lead webcam">Long Mynd West</p>
                     <img
-                        id="longmynd-west-cam"
                         height="480"
                         width="640"
                         src="https://www.midlandgliding.club/piwebcam/144.jpg"
@@ -282,23 +281,6 @@
             crossorigin="anonymous"
         ></script>
         <script src="../assets/js/weather.js" type="text/javascript"></script>
-
-        <script>
-            (function () {
-                var SRC = 'https://www.midlandgliding.club/piwebcam/westcam.html';
-                fetch(SRC, { cache: 'no-store' })
-                    .then(function (r) { return r.ok ? r.text() : Promise.reject(r.status); })
-                    .then(function (html) {
-                        var re = /https:\/\/www\.midlandgliding\.club\/piwebcam\/\d+\.jpg[^'"\s]*/g;
-                        var matches = html.match(re);
-                        if (!matches || !matches.length) return;
-                        document.getElementById('longmynd-west-cam').src = matches[matches.length - 1];
-                    })
-                    .catch(function (e) {
-                        console.warn('Long Mynd West dynamic fetch failed:', e);
-                    });
-            })();
-        </script>
 
         <!-- Global site tag (gtag.js) - Google Analytics -->
         <script async src="https://www.googletagmanager.com/gtag/js?id=UA-56060801-2"></script>

--- a/webcams/index.html
+++ b/webcams/index.html
@@ -161,9 +161,10 @@
                 <div class="col-md-6">
                     <p class="lead webcam">Long Mynd West</p>
                     <img
+                        id="longmynd-west-cam"
                         height="480"
                         width="640"
-                        src="https://www.midlandgliding.club/piwebcam/MGC.jpg"
+                        src="https://www.midlandgliding.club/piwebcam/144.jpg"
                         class="img-responsive img-rounded"
                         alt="Long Mynd West Webcam"
                     />
@@ -281,6 +282,23 @@
             crossorigin="anonymous"
         ></script>
         <script src="../assets/js/weather.js" type="text/javascript"></script>
+
+        <script>
+            (function () {
+                var SRC = 'https://www.midlandgliding.club/piwebcam/westcam.html';
+                fetch(SRC, { cache: 'no-store' })
+                    .then(function (r) { return r.ok ? r.text() : Promise.reject(r.status); })
+                    .then(function (html) {
+                        var re = /https:\/\/www\.midlandgliding\.club\/piwebcam\/\d+\.jpg[^'"\s]*/g;
+                        var matches = html.match(re);
+                        if (!matches || !matches.length) return;
+                        document.getElementById('longmynd-west-cam').src = matches[matches.length - 1];
+                    })
+                    .catch(function (e) {
+                        console.warn('Long Mynd West dynamic fetch failed:', e);
+                    });
+            })();
+        </script>
 
         <!-- Global site tag (gtag.js) - Google Analytics -->
         <script async src="https://www.googletagmanager.com/gtag/js?id=UA-56060801-2"></script>

--- a/webcams/index.html
+++ b/webcams/index.html
@@ -148,11 +148,11 @@
                 </div>
 
                 <div class="col-md-6">
-                    <p class="lead webcam">Long Mynd South</p>
+                    <p class="lead webcam">Long Mynd East</p>
                     <img
                         height="480"
                         width="640"
-                        src="https://www.mysolarcam.com/LongMyndSouth/last.jpg"
+                        src="https://www.midlandgliding.club/piwebcam/hangarcam/200.jpg"
                         class="img-responsive img-rounded"
                         alt="Long Mynd South Webcam"
                     />
@@ -163,7 +163,7 @@
                     <img
                         height="480"
                         width="640"
-                        src="https://www.midlandgliding.club/piwebcam/144.jpg"
+                        src="https://www.midlandgliding.club/piwebcam/100.jpg"
                         class="img-responsive img-rounded"
                         alt="Long Mynd West Webcam"
                     />
@@ -259,14 +259,14 @@
                     />
                 </div>
 
-                <div class="col-md-12">
+                <!-- <div class="col-md-12">
                     <p class="lead webcam">Rattlesden West</p>
                     <img
                         src="https://ratair.stratus.org.uk/wc/cam1.jpg"
                         class="img-responsive img-rounded"
                         alt="Rattlesden West Webcam"
                     />
-                </div>
+                </div> -->
             </div>
         </div>
 


### PR DESCRIPTION
The cam source is a JS slideshow over 45 rolling-buffer JPEGs in
piwebcam/. Fetch the page client-side on load and point the <img> at
the last entry in its A_ITEMS array so we automatically track whichever
slot the source treats as the latest, with 144.jpg as a static fallback
if the cross-origin fetch is blocked.